### PR TITLE
Build script for containers using musl library

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:latest
+
+RUN apk add --no-cache git make musl-dev go
+
+# Configure Go
+ENV GOROOT /usr/lib/go
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+
+COPY . ${GOPATH}/src
+
+# Install Glide
+RUN go get -u github.com/Masterminds/glide/...
+
+WORKDIR $GOPATH/src
+
+RUN go mod download && go build && \
+    mkdir -p $GOPATH/bin && mv simple-iam-vault-cli $GOPATH/bin/simple-iam-vault-cli
+
+CMD ["simple-iam-vault-cli"]

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# There's no way to build musl binaries with github
+# so we need to compile it inside a container
+# and manually push the binary to github
+
+VERSION=${VERSION:=0.18}
+
+DOCKERFILE=${DOCKERFILE:-Dockerfile}
+
+docker build -f ${DOCKERFILE} -t devfh/simple-iam-vault-cli:${VERSION} ..
+docker create -it --name simple-iam-vault-cli-build devfh/simple-iam-vault-cli:${VERSION} bash
+docker cp simple-iam-vault-cli-build:/go/bin/simple-iam-vault-cli .
+docker rm -f simple-iam-vault-cli-build


### PR DESCRIPTION
Because there's no way for github actions to build golang binaries with musl library, we need to spin up a container, compile it there, and manually upload to Releases.
